### PR TITLE
Fixes #1 -- ngc errors cause the gulp-ngc plugin fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea
+npm-debug.log*
+node_modules/
+

--- a/dist/index.js
+++ b/dist/index.js
@@ -15,15 +15,17 @@ var index = (configPath) => {
 
     return gulp.src(configPath)
         .pipe(through.obj((file, encoding, callback) => {
-            _angular_compilerCli_src_main.main(args).then((code) => {
-                let err = code === 0
-                        ?null: new gutil.PluginError(
+            _angular_compilerCli_src_main.main(args)
+                .then((code) => {
+                    let err = code === 0
+                        ? null
+                        : new gutil.PluginError(
                             'gulp-ngc',
-                            'Compilation error. See details in the ngc output',
+                            `${gutil.colors.red('Compilation error.')}\nSee details in the ngc output`,
                             {fileName: file.path});
 
                     callback(err, file);
-            }); 
+                });
         }));
 };
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -11,12 +11,19 @@ var index = (configPath) => {
         _: [],
         p: configPath
     };
-    
+
     return gulp.src(configPath)
         .pipe(through.obj((file, encoding, callback) => {
-            _angular_compilerCli_src_main.main(args).then(() => {
-                callback(null, file); 
-            }); 
+            _angular_compilerCli_src_main.main(args)
+                .then((code) => {
+                    let err = code === 0
+                        ? null
+                        : new gutil.PluginError(
+                            'gulp-ngc',
+                            'Compilation error. See details in the ngc output',
+                            {fileName: file.path});
+                    callback(err, file);
+                });
         }));
 };
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -3,6 +3,7 @@
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
 var gulp = _interopDefault(require('gulp'));
+var gutil = _interopDefault(require('gulp-util'));
 var through = _interopDefault(require('through2'));
 var _angular_compilerCli_src_main = require('@angular/compiler-cli/src/main');
 
@@ -14,16 +15,15 @@ var index = (configPath) => {
 
     return gulp.src(configPath)
         .pipe(through.obj((file, encoding, callback) => {
-            _angular_compilerCli_src_main.main(args)
-                .then((code) => {
-                    let err = code === 0
-                        ? null
-                        : new gutil.PluginError(
+            _angular_compilerCli_src_main.main(args).then((code) => {
+                let err = code === 0
+                        ?null: new gutil.PluginError(
                             'gulp-ngc',
                             'Compilation error. See details in the ngc output',
                             {fileName: file.path});
+
                     callback(err, file);
-                });
+            }); 
         }));
 };
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@angular/compiler-cli": "^2.4.1",
     "gulp": "^3.9.1",
+    "gulp-util": "^3.0.8",
     "through2": "^2.0.3"
   },
   "devDependencies": {

--- a/rollup-config.js
+++ b/rollup-config.js
@@ -6,6 +6,7 @@ export default {
     external: [
         'gulp',
         'through2',
+        'gulp-util',
         '@angular/compiler-cli/src/main'
     ]
 }

--- a/rollup-config.js
+++ b/rollup-config.js
@@ -1,8 +1,11 @@
-import rollup      from 'rollup';
-
 export default {
     entry: 'src/index.js',
     dest: 'dist/index.js',
     sourceMap: false,
-    format: 'cjs'
+    format: 'cjs',
+    external: [
+        'gulp',
+        'through2',
+        '@angular/compiler-cli/src/main'
+    ]
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import gulp from 'gulp';
+import gutil from 'gulp-util';
 import through from 'through2';
 import {main as ngc} from '@angular/compiler-cli/src/main';
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ export default (configPath) => {
                         ? null
                         : new gutil.PluginError(
                             'gulp-ngc',
-                            'Compilation error. See details in the ngc output',
+                            `${gutil.colors.red('Compilation error.')}\nSee details in the ngc output`,
                             {fileName: file.path});
 
                     callback(err, file);

--- a/src/index.js
+++ b/src/index.js
@@ -10,11 +10,19 @@ export default (configPath) => {
         _: [],
         p: configPath
     };
-    
+
     return gulp.src(configPath)
         .pipe(through.obj((file, encoding, callback) => {
-            ngc(args).then(() => {
-                callback(null, file); 
-            }); 
+            ngc(args)
+                .then((code) => {
+                    let err = code === 0
+                        ? null
+                        : new gutil.PluginError(
+                            'gulp-ngc',
+                            'Compilation error. See details in the ngc output',
+                            {fileName: file.path});
+
+                    callback(err, file);
+                });
         }));
 };


### PR DESCRIPTION
-- ngc errors cause the gulp-ngc plugin fail with non-zero exit code;
-- added .gitignore;
-- cleared rollup build output