### PR TITLE
Allow custom NGC options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,16 @@ gulp.task('rollup', ['ngc'], () => {
         .pipe(gulp.dest('./dist'));
 });
 ```
+
+Using NGC options:
+```js
+
+gulp.task('ngc', () => {
+    return ngc('tsconfig.json', {
+         i18nFile: './src/locale/messages.fr.xlf',
+         locale: 'fr',
+         i18nFormat: 'xlf',
+    });
+});
+
+```

--- a/dist/index.js
+++ b/dist/index.js
@@ -7,11 +7,17 @@ var gutil = _interopDefault(require('gulp-util'));
 var through = _interopDefault(require('through2'));
 var _angular_compilerCli_src_main = require('@angular/compiler-cli/src/main');
 
-var index = (configPath) => {
-    let args = {
-        _: [],
-        p: configPath
-    };
+var index = (configPath, ngcArgs) => {
+
+    let args = {};
+
+    if (typeof configPath === 'object') {
+        args = configPath;
+    } else if (typeof ngcArgs === 'object') {
+        args = ngcArgs;
+    }
+    args._ = args._ || [];
+    args.p = args.p || configPath;
 
     return gulp.src(configPath)
         .pipe(through.obj((file, encoding, callback) => {

--- a/src/index.js
+++ b/src/index.js
@@ -6,11 +6,17 @@ import through from 'through2';
 import {main as ngc} from '@angular/compiler-cli/src/main';
 
 
-export default (configPath) => {
-    let args = {
-        _: [],
-        p: configPath
-    };
+export default (configPath, ngcArgs) => {
+
+    let args = {};
+
+    if (typeof configPath === 'object') {
+        args = configPath;
+    } else if (typeof ngcArgs === 'object') {
+        args = ngcArgs;
+    }
+    args._ = args._ || [];
+    args.p = args.p || configPath;
 
     return gulp.src(configPath)
         .pipe(through.obj((file, encoding, callback) => {


### PR DESCRIPTION
Added NGC options as an object. Kept backwards compatibility. Also allow for only NGC options in which the user can define "p" or "project" key if desired. By default, NGC would get tsconfig.json in the current folder.

Added a usage example aswell.