### PR TITLE
upgrade to gulp 4

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5,7 +5,9 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
 var gulp = _interopDefault(require('gulp'));
 var gutil = _interopDefault(require('gulp-util'));
 var through = _interopDefault(require('through2'));
-var _angular_compilerCli_src_main = require('@angular/compiler-cli/src/main');
+var main = require('@angular/compiler-cli/src/main');
+
+'use strict';
 
 var index = (configPath, ngcArgs) => {
 
@@ -21,7 +23,7 @@ var index = (configPath, ngcArgs) => {
 
     return gulp.src(configPath)
         .pipe(through.obj((file, encoding, callback) => {
-            _angular_compilerCli_src_main.main(args)
+            main.main(args)
                 .then((code) => {
                     let err = code === 0
                         ? null

--- a/package.json
+++ b/package.json
@@ -5,12 +5,17 @@
   },
   "description": "Extremely simple and dummy gulp plugin who wraps @angular/compiler-cli",
   "dependencies": {
-    "@angular/compiler-cli": ">=2.4.1",
-    "gulp": ">=3.9.1",
+    "@angular/compiler-cli": "^4.1.1",
+    "@angular/compiler": "^4.1.1",
+    "@angular/core": "^4.1.1",
+    "rxjs": "^5.4.3",
+    "zone.js": "^0.8.18",
+    "gulp": "github:gulpjs/gulp#4.0",
     "gulp-util": ">=3.0.8",
     "through2": ">=2.0.3"
   },
   "devDependencies": {
+    "typescript": "^2.5.3",
     "rollup": ">=0.38.2"
   },
   "engines": {
@@ -38,5 +43,5 @@
   "scripts": {
     "build": "node_modules/.bin/rollup -c rollup-config.js"
   },
-  "version": "0.3.2"
+  "version": "4.0.0"
 }


### PR DESCRIPTION
may seem pedantic but this was causing some NPM warnings due to old minimatch dependencies in < gulp 4. sorry about the changes in the dist file. I can edit it by hand if you want or if you let me know how you configured rollup.js to use the friendlier name I'll do it that way